### PR TITLE
feat: SaveDataWindowに自作JSONエディタを導入＆型定義SaveDataを導出

### DIFF
--- a/src/components/EditScreen/EditScreen.tsx
+++ b/src/components/EditScreen/EditScreen.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { SaveDataEditor } from "./SaveDataWindow";
-import type { SaveData } from "./SaveDataWindow";
 import { CommandWindow } from "./CommandWindow";
 import "./edit-screen.css";
 
 type EditScreenProps = {
-  saveData: SaveData;
+  saveData: object;
 };
 
 export const EditScreen: React.FC<EditScreenProps> = ({ saveData }) => {

--- a/src/components/EditScreen/EditScreen.tsx
+++ b/src/components/EditScreen/EditScreen.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { SaveDataEditor } from "./SaveDataWindow";
+import type { SaveData } from "./SaveDataWindow";
 import { CommandWindow } from "./CommandWindow";
 import "./edit-screen.css";
 
 type EditScreenProps = {
-  saveData: object;
+  saveData: SaveData;
 };
 
 export const EditScreen: React.FC<EditScreenProps> = ({ saveData }) => {

--- a/src/components/EditScreen/SaveDataWindow.tsx
+++ b/src/components/EditScreen/SaveDataWindow.tsx
@@ -1,11 +1,7 @@
 import React, { useState, useEffect } from "react";
 
-export interface SaveData {
-  [key: string]: unknown;
-}
-
 interface SaveDataEditorProps {
-  saveData: SaveData;
+  saveData: object;
 }
 
 export const SaveDataEditor: React.FC<SaveDataEditorProps> = ({ saveData }) => {

--- a/src/components/EditScreen/SaveDataWindow.tsx
+++ b/src/components/EditScreen/SaveDataWindow.tsx
@@ -1,13 +1,28 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+
+export interface SaveData {
+  [key: string]: unknown;
+}
 
 interface SaveDataEditorProps {
-  saveData: object;
+  saveData: SaveData;
 }
 
 export const SaveDataEditor: React.FC<SaveDataEditorProps> = ({ saveData }) => {
+  const [jsonText, setJsonText] = useState<string>("");
+
+  useEffect(() => {
+    setJsonText(JSON.stringify(saveData, null, 2));
+  }, [saveData]);
+
   return (
     <div className="save-data-window">
-      <pre>{JSON.stringify(saveData, null, 2)}</pre>
+      <textarea
+        value={jsonText}
+        onChange={e => setJsonText(e.target.value)}
+        className="json-editor"
+        spellCheck={false}
+      />
     </div>
   );
 };

--- a/src/components/EditScreen/edit-screen.css
+++ b/src/components/EditScreen/edit-screen.css
@@ -1,6 +1,6 @@
 .edit-screen {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   height: 100vh;
 }
 
@@ -10,11 +10,19 @@
   border-radius: 12px;
   background-color: black;
   width: calc(100% - 320px);
-  overflow-y: auto;
 }
 
-.save-data-window pre {
-  font-size: 18px;
+.json-editor {
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  color: white;
+  font-family: monospace;
+  font-size: 16px;
+  border: none;
+  padding: 12px;
+  box-sizing: border-box;
+  resize: none;
 }
 
 .command-window {


### PR DESCRIPTION
- SaveDataWindow.tsx をプレーン表示から編集可能なエディタに変更
- JSONテキストの編集状態をuseStateで管理
- スクロールの二重化問題をCSSで解消
- SaveData型を定義・exportし、EditScreenと共有