### PR TITLE
feat: 保存機能の実装

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -50,17 +50,14 @@ app.on("activate", () => {
 
 app.whenReady().then(createWindow);
 
-ipcMain.on("save-rpgsave-file", async (_, data: string) => {
-  const win = BrowserWindow.getFocusedWindow();
-  if (!win) return;
-
-  const result = await dialog.showSaveDialog(win, {
-    title: "セーブ　しますか？",
-    defaultPath: "file1.rpgsave",
-    filters: [{ name: "RPGツクールMV セーブデータ", extensions: ["rpgsave"] }],
+ipcMain.handle("save-rpgsave-file", async (_event, data: string, fileName: string) => {
+  const { canceled, filePath } = await dialog.showSaveDialog({
+    title: "セーブデータを保存",
+    defaultPath: fileName,
+    filters: [{ name: "RPGセーブデータ", extensions: ["rpgsave"] }],
   });
 
-  if (!result.canceled && result.filePath) {
-    fs.writeFileSync(result.filePath, data, "utf-8");
+  if (!canceled && filePath) {
+    fs.writeFileSync(filePath, data, "utf-8");
   }
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog, ipcMain } from "electron";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import fs from "fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -48,3 +49,18 @@ app.on("activate", () => {
 });
 
 app.whenReady().then(createWindow);
+
+ipcMain.on("save-rpgsave-file", async (_, data: string) => {
+  const win = BrowserWindow.getFocusedWindow();
+  if (!win) return;
+
+  const result = await dialog.showSaveDialog(win, {
+    title: "セーブデータを保存",
+    defaultPath: "Save1.rpgsave",
+    filters: [{ name: "RPGセーブデータ", extensions: ["rpgsave"] }],
+  });
+
+  if (!result.canceled && result.filePath) {
+    fs.writeFileSync(result.filePath, data, "utf-8");
+  }
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,9 +55,9 @@ ipcMain.on("save-rpgsave-file", async (_, data: string) => {
   if (!win) return;
 
   const result = await dialog.showSaveDialog(win, {
-    title: "セーブデータを保存",
-    defaultPath: "Save1.rpgsave",
-    filters: [{ name: "RPGセーブデータ", extensions: ["rpgsave"] }],
+    title: "セーブ　しますか？",
+    defaultPath: "file1.rpgsave",
+    filters: [{ name: "RPGツクールMV セーブデータ", extensions: ["rpgsave"] }],
   });
 
   if (!result.canceled && result.filePath) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld("ipcRenderer", {
 });
 
 contextBridge.exposeInMainWorld("electron", {
-  saveRpgsaveFile: (data: string) => ipcRenderer.send("save-rpgsave-file", data),
-  openDialog: () => ipcRenderer.invoke("open-dialog"),
+  saveRpgsaveFile: (data: string, fileName: string) => {
+    ipcRenderer.invoke("save-rpgsave-file", data, fileName);
+  },
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,6 +1,5 @@
 import { ipcRenderer, contextBridge } from "electron";
 
-// --------- Expose some API to the Renderer process ---------
 contextBridge.exposeInMainWorld("ipcRenderer", {
   on(...args: Parameters<typeof ipcRenderer.on>) {
     const [channel, listener] = args;
@@ -18,7 +17,9 @@ contextBridge.exposeInMainWorld("ipcRenderer", {
     const [channel, ...omit] = args;
     return ipcRenderer.invoke(channel, ...omit);
   },
+});
 
-  // You can expose other APTs you need here.
-  // ...
+contextBridge.exposeInMainWorld("electron", {
+  saveRpgsaveFile: (data: string) => ipcRenderer.send("save-rpgsave-file", data),
+  openDialog: () => ipcRenderer.invoke("open-dialog"),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,12 @@ import { EditScreen } from "./components/EditScreen/EditScreen.tsx";
 
 const App: React.FC = () => {
   const [saveData, setSaveData] = useState<object | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
 
   return !saveData ? (
-    <StartScreen onLoad={setSaveData} />
+    <StartScreen onLoad={setSaveData} setFileName={setFileName} />
   ) : (
-    <EditScreen saveData={saveData} setSaveData={setSaveData} />
+    <EditScreen saveData={saveData} setSaveData={setSaveData} fileName={fileName} />
   );
 };
 

--- a/src/components/EditScreen/CommandWindow.tsx
+++ b/src/components/EditScreen/CommandWindow.tsx
@@ -10,6 +10,7 @@ interface CommandWindowProps {
   query: string;
   setQuery: (value: string) => void;
   setNextIndex: (value: number) => void;
+  fileName: string | null;
 }
 
 export const CommandWindow: React.FC<CommandWindowProps> = ({
@@ -18,6 +19,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
   query,
   setQuery,
   setNextIndex,
+  fileName,
 }) => {
   return (
     <div className="command-window">
@@ -33,7 +35,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
         setQuery={setQuery}
         setNextIndex={setNextIndex}
       />
-      <SavePanel saveData={saveData} />
+      <SavePanel saveData={saveData} fileName={fileName} />
     </div>
   );
 };

--- a/src/components/EditScreen/CommandWindow.tsx
+++ b/src/components/EditScreen/CommandWindow.tsx
@@ -33,7 +33,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
         setQuery={setQuery}
         setNextIndex={setNextIndex}
       />
-      <SavePanel />
+      <SavePanel saveData={saveData} />
     </div>
   );
 };

--- a/src/components/EditScreen/CommandWindow.tsx
+++ b/src/components/EditScreen/CommandWindow.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { SearchPanel } from "./CommandWindow/SearchPanel";
 import { MoneyEditPanel } from "./CommandWindow/MoneyEditPanel";
+import { SavePanel } from "./CommandWindow/SavePanel";
 
 interface CommandWindowProps {
   saveData: object | null;
@@ -32,6 +33,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
         setQuery={setQuery}
         setNextIndex={setNextIndex}
       />
+      <SavePanel />
     </div>
   );
 };

--- a/src/components/EditScreen/CommandWindow/SavePanel.tsx
+++ b/src/components/EditScreen/CommandWindow/SavePanel.tsx
@@ -4,16 +4,17 @@ import { compressToBase64 } from "lz-string";
 
 interface SavePanelProps {
   saveData: object | null;
+  fileName: string | null;
 }
 
-export const SavePanel: React.FC<SavePanelProps> = ({ saveData }) => {
+export const SavePanel: React.FC<SavePanelProps> = ({ saveData, fileName }) => {
   const handleClick = () => {
-    if (!saveData) return;
+    if (!saveData || !fileName) return;
 
     const json = JSON.stringify(saveData);
     const compressed = compressToBase64(json);
 
-    window.electron?.saveRpgsaveFile(compressed);
+    window.electron?.saveRpgsaveFile(compressed, fileName);
   };
 
   return (

--- a/src/components/EditScreen/CommandWindow/SavePanel.tsx
+++ b/src/components/EditScreen/CommandWindow/SavePanel.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import "./save-panel.css";
+
+export const SavePanel: React.FC = () => {
+  return (
+    <div className="save-panel">
+      <button className="save-button">ほぞん</button>
+    </div>
+  );
+};

--- a/src/components/EditScreen/CommandWindow/SavePanel.tsx
+++ b/src/components/EditScreen/CommandWindow/SavePanel.tsx
@@ -1,10 +1,26 @@
 import React from "react";
 import "./save-panel.css";
+import { compressToBase64 } from "lz-string";
 
-export const SavePanel: React.FC = () => {
+interface SavePanelProps {
+  saveData: object | null;
+}
+
+export const SavePanel: React.FC<SavePanelProps> = ({ saveData }) => {
+  const handleClick = () => {
+    if (!saveData) return;
+
+    const json = JSON.stringify(saveData, null, 2);
+    const compressed = compressToBase64(json);
+
+    window.electron?.saveRpgsaveFile(compressed);
+  };
+
   return (
     <div className="save-panel">
-      <button className="save-button">ほぞん</button>
+      <button className="save-button" onClick={handleClick}>
+        ほぞん
+      </button>
     </div>
   );
 };

--- a/src/components/EditScreen/CommandWindow/SavePanel.tsx
+++ b/src/components/EditScreen/CommandWindow/SavePanel.tsx
@@ -10,7 +10,7 @@ export const SavePanel: React.FC<SavePanelProps> = ({ saveData }) => {
   const handleClick = () => {
     if (!saveData) return;
 
-    const json = JSON.stringify(saveData, null, 2);
+    const json = JSON.stringify(saveData);
     const compressed = compressToBase64(json);
 
     window.electron?.saveRpgsaveFile(compressed);

--- a/src/components/EditScreen/CommandWindow/save-panel.css
+++ b/src/components/EditScreen/CommandWindow/save-panel.css
@@ -1,0 +1,19 @@
+.save-panel {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+.save-button {
+  cursor: pointer;
+  border: 2px solid white;
+  background-color: black;
+  padding: 4px 16px;
+  color: white;
+  font-size: 16px;
+}
+
+.save-button:hover {
+  background-color: white;
+  color: black;
+}

--- a/src/components/EditScreen/EditScreen.tsx
+++ b/src/components/EditScreen/EditScreen.tsx
@@ -7,9 +7,10 @@ import "./edit-screen.css";
 type EditScreenProps = {
   saveData: object | null;
   setSaveData: (data: object) => void;
+  fileName: string | null;
 };
 
-export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData }) => {
+export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData, fileName }) => {
   const [query, setQuery] = useState("");
   const [nextIndex, setNextIndex] = useState<number>(-1);
 
@@ -22,6 +23,7 @@ export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData })
         query={query}
         setQuery={setQuery}
         setNextIndex={setNextIndex}
+        fileName={fileName}
       />
     </div>
   );

--- a/src/components/StartScreen/DropZone.tsx
+++ b/src/components/StartScreen/DropZone.tsx
@@ -3,9 +3,10 @@ import { decompressFromBase64 } from "lz-string";
 
 type DropZoneProps = {
   onLoad: (json: object) => void;
+  setFileName: (name: string) => void;
 };
 
-export const DropZone: React.FC<DropZoneProps> = ({ onLoad }) => {
+export const DropZone: React.FC<DropZoneProps> = ({ onLoad, setFileName }) => {
   const handleDrop = (e: React.DragEvent<HTMLImageElement>) => {
     e.preventDefault();
 
@@ -24,6 +25,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ onLoad }) => {
 
         const json = JSON.parse(jsonStr);
         onLoad(json);
+        setFileName(file.name);
       } catch {
         alert("データが　よみこめなかった！\nこわれている　か　まちがっている　かも　しれないぞ。");
       }

--- a/src/components/StartScreen/StartScreen.tsx
+++ b/src/components/StartScreen/StartScreen.tsx
@@ -6,13 +6,14 @@ import "./start-screen.css";
 
 type StartScreenProps = {
   onLoad: (json: object) => void;
+  setFileName: (name: string) => void;
 };
 
-export const StartScreen: React.FC<StartScreenProps> = ({ onLoad }) => {
+export const StartScreen: React.FC<StartScreenProps> = ({ onLoad, setFileName }) => {
   return (
     <div className="start-screen">
       <Logo />
-      <DropZone onLoad={onLoad} />
+      <DropZone onLoad={onLoad} setFileName={setFileName} />
     </div>
   );
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  interface Window {
+    electron: {
+      saveRpgsaveFile: (data: string, fileName: string) => Promise<void>;
+    };
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+export {};
+
+declare global {
+  interface Window {
+    electron: {
+      saveRpgsaveFile: (data: string) => void;
+      openDialog: () => Promise<string | null>;
+    };
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,12 +1,1 @@
 /// <reference types="vite/client" />
-
-export {};
-
-declare global {
-  interface Window {
-    electron: {
-      saveRpgsaveFile: (data: string) => void;
-      openDialog: () => Promise<string | null>;
-    };
-  }
-}


### PR DESCRIPTION
編集画面で「ほぞん」ボタンをクリックするとセーブデータを保存できる機能を実装しました。
保存時のファイル名は参照元と同じにしました。固定だと手動変更が手間なので利便性を考慮しました。