### PR TITLE
refactor: fileName を filePath に変更し保存先を参照元に指定

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,12 @@ import { EditScreen } from "./components/EditScreen/EditScreen";
 
 const App: React.FC = () => {
   const [saveData, setSaveData] = useState<object | null>(null);
-  const [fileName, setFileName] = useState<string | null>(null);
+  const [filePath, setFilePath] = useState<string | null>(null);
 
   return !saveData ? (
-    <StartScreen onLoad={setSaveData} setFileName={setFileName} />
+    <StartScreen onLoad={setSaveData} setFilePath={setFilePath} />
   ) : (
-    <EditScreen saveData={saveData} setSaveData={setSaveData} fileName={fileName} />
+    <EditScreen saveData={saveData} setSaveData={setSaveData} filePath={filePath} />
   );
 };
 

--- a/src/components/EditScreen/CommandWindow.tsx
+++ b/src/components/EditScreen/CommandWindow.tsx
@@ -13,7 +13,7 @@ interface CommandWindowProps {
   silentQuery: boolean;
   setSilentQuery: (value: boolean) => void;
   setNextIndex: (value: number) => void;
-  fileName: string | null;
+  filePath: string | null;
 }
 
 export const CommandWindow: React.FC<CommandWindowProps> = ({
@@ -24,7 +24,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
   silentQuery,
   setSilentQuery,
   setNextIndex,
-  fileName,
+  filePath,
 }) => {
   return (
     <div className="command-window">
@@ -50,7 +50,7 @@ export const CommandWindow: React.FC<CommandWindowProps> = ({
         setSilentQuery={setSilentQuery}
         setNextIndex={setNextIndex}
       />
-      <ActionPanel saveData={saveData} setSaveData={setSaveData} fileName={fileName} />
+      <ActionPanel saveData={saveData} setSaveData={setSaveData} filePath={filePath} />
     </div>
   );
 };

--- a/src/components/EditScreen/CommandWindow/ActionPanel.tsx
+++ b/src/components/EditScreen/CommandWindow/ActionPanel.tsx
@@ -5,17 +5,17 @@ import { compressToBase64 } from "lz-string";
 interface ActionPanelProps {
   saveData: object | null;
   setSaveData: (data: object | null) => void;
-  fileName: string | null;
+  filePath: string | null;
 }
 
-export const ActionPanel: React.FC<ActionPanelProps> = ({ saveData, setSaveData, fileName }) => {
+export const ActionPanel: React.FC<ActionPanelProps> = ({ saveData, setSaveData, filePath }) => {
   const handleClick = () => {
-    if (!(saveData && fileName)) return;
+    if (!(saveData && filePath)) return;
 
     const json = JSON.stringify(saveData as object);
     const compressed = compressToBase64(json);
 
-    window.electron?.saveRpgsaveFile(compressed, fileName);
+    window.electron?.saveRpgsaveFile(compressed, filePath);
   };
 
   return (

--- a/src/components/EditScreen/EditScreen.tsx
+++ b/src/components/EditScreen/EditScreen.tsx
@@ -7,10 +7,10 @@ import "./edit-screen.css";
 type EditScreenProps = {
   saveData: object | null;
   setSaveData: (data: object | null) => void;
-  fileName: string | null;
+  filePath: string | null;
 };
 
-export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData, fileName }) => {
+export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData, filePath }) => {
   const [query, setQuery] = useState("");
   const [silentQuery, setSilentQuery] = useState(false);
   const [nextIndex, setNextIndex] = useState<number>(-1);
@@ -31,7 +31,7 @@ export const EditScreen: React.FC<EditScreenProps> = ({ saveData, setSaveData, f
         silentQuery={silentQuery}
         setSilentQuery={setSilentQuery}
         setNextIndex={setNextIndex}
-        fileName={fileName}
+        filePath={filePath}
       />
     </div>
   );

--- a/src/components/StartScreen/DropZone.tsx
+++ b/src/components/StartScreen/DropZone.tsx
@@ -3,10 +3,10 @@ import { decompressFromBase64 } from "lz-string";
 
 type DropZoneProps = {
   onLoad: (json: object) => void;
-  setFileName: (name: string) => void;
+  setFilePath: (path: string) => void;
 };
 
-export const DropZone: React.FC<DropZoneProps> = ({ onLoad, setFileName }) => {
+export const DropZone: React.FC<DropZoneProps> = ({ onLoad, setFilePath }) => {
   const handleDrop = (e: React.DragEvent<HTMLImageElement>) => {
     e.preventDefault();
 
@@ -17,7 +17,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ onLoad, setFileName }) => {
     }
 
     const file = files[0];
-    if (!file.name.endsWith(".rpgsave")) {
+    if (!file.path.endsWith(".rpgsave")) {
       alert("Not a .rpgsave file.");
       return;
     }
@@ -30,7 +30,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ onLoad, setFileName }) => {
         const json = JSON.parse(jsonStr);
 
         onLoad(json);
-        setFileName(file.name);
+        setFilePath(file.path);
       } catch {
         alert("Cannot load. Maybe broken.");
       }

--- a/src/components/StartScreen/StartScreen.tsx
+++ b/src/components/StartScreen/StartScreen.tsx
@@ -6,14 +6,14 @@ import "./start-screen.css";
 
 type StartScreenProps = {
   onLoad: (json: object) => void;
-  setFileName: (name: string) => void;
+  setFilePath: (path: string) => void;
 };
 
-export const StartScreen: React.FC<StartScreenProps> = ({ onLoad, setFileName }) => {
+export const StartScreen: React.FC<StartScreenProps> = ({ onLoad, setFilePath }) => {
   return (
     <div className="start-screen">
       <Logo />
-      <DropZone onLoad={onLoad} setFileName={setFileName} />
+      <DropZone onLoad={onLoad} setFilePath={setFilePath} />
     </div>
   );
 };


### PR DESCRIPTION
- 利用者は新規保存よりも上書き保存を操作すると感じたので、利便性を向上させる為に保存先を参照元に変更した。